### PR TITLE
Add alternative factory method to add services

### DIFF
--- a/examples/with_decorators.py
+++ b/examples/with_decorators.py
@@ -30,6 +30,11 @@ class EchoService:
         )
 
 
+#
+# Alternatively, service(s) can be registered like this, to pass context or client into the service.
+#     services= lambda ctx: [EchoService(some_configuration="some value"),],
+#
+        
 if __name__ == "__main__":
     micro.sdk.run(
         servers=["nats://localhost:4222"],


### PR DESCRIPTION
Alternative way to pass a factory method when adding new services.
This allow the passing of context (or Client of the context) to the constructor of the service.

Alternatively to this:
```
    micro.sdk.run(
        servers=["nats://localhost:4222"],
        services=[
            EchoService(some_configuration="some value"),
        ],
        trap_signals=True,
    )

```

this also works:

```
    micro.sdk.run(
        servers=["nats://localhost:4222"],
        services=lambda ctx: EchoService(ctx, some_configuration="some value"),
        trap_signals=True,
    )

```
There can be multiple services created. Lambda (or callable) return an iterable of services.